### PR TITLE
upgraded to 2.7.0 of the Couchbase SDK

### DIFF
--- a/Hangfire.Couchbase/Hangfire.Couchbase.csproj
+++ b/Hangfire.Couchbase/Hangfire.Couchbase.csproj
@@ -29,7 +29,7 @@
     <DocumentationFile>bin\Release\netstandard2.0\Hangfire.Couchbase.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CouchbaseNetClient" Version="2.6.1" />
+    <PackageReference Include="CouchbaseNetClient" Version="2.7.0" />
     <PackageReference Include="Hangfire.Core" Version="1.6.20" />
     <PackageReference Include="Linq2Couchbase" Version="1.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />


### PR DESCRIPTION
Upgrading this project to used Couchbase .NET SDK 2.7.0. Nothing too crazy here, but a handful of fixes/improvements that might come in handy: https://docs.couchbase.com/dotnet-sdk/2.7/relnotes-dotnet-sdk.html#version-2-7-0-2nd-october-2018